### PR TITLE
pinned cowlib and ranch to pre erl19-requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ CI_OTP ?= OTP-18.0.3 OTP-18.1.5 OTP-18.2.4.1 OTP-18.3.4.4 OTP-19.0.7 OTP-19.1.6
 LOCAL_DEPS = ssl
 
 DEPS = cowlib ranch
-dep_cowlib = git https://github.com/ninenines/cowlib master
-dep_ranch = git https://github.com/ninenines/ranch master
+dep_cowlib = git https://github.com/ninenines/cowlib 45f750db410a4b08c68d142ad0af839f544c5d3d
+dep_ranch = git https://github.com/ninenines/ranch a004ad710eddd0c21aaccc30d5633a76b06164b5
 
 TEST_DEPS = ct_helper
 dep_ct_helper = git https://github.com/extend/ct_helper.git master

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-{cowlib,".*",{git,"https://github.com/ninenines/cowlib","master"}},{ranch,".*",{git,"https://github.com/ninenines/ranch","master"}}
+{cowlib,".*",{git,"https://github.com/ninenines/cowlib","45f750db410a4b08c68d142ad0af839f544c5d3d"}},{ranch,".*",{git,"https://github.com/ninenines/ranch","a004ad710eddd0c21aaccc30d5633a76b06164b5"}}
 ]}.
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard]}.


### PR DESCRIPTION
- as of earlier this morning, the master branch of `cowlib` requires erl19
- gun's deps are all pinned to master, therefore this requirement translates to gun as well
- this commit pins the deps to commits just prior to the introduction of this requirement