### PR TITLE
pin cowlib 2.0.0-pre.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CI_OTP = OTP-18.0.2
 # Dependencies.
 
 DEPS = cowlib ranch
-dep_cowlib = git https://github.com/ninenines/cowlib 1.3.0
+dep_cowlib = git https://github.com/ninenines/cowlib 2.0.0-pre.1
 dep_ranch = git https://github.com/ninenines/ranch 1.1.0
 
 TEST_DEPS = ct_helper

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-	{cowlib, ".*", {git, "git://github.com/extend/cowlib.git", "1.3.0"}},
+	{cowlib, ".*", {git, "git://github.com/extend/cowlib.git", "2.0.0-pre.1"}},
 	{ranch, ".*", {git, "git://github.com/extend/ranch.git", "1.1.0"}}
 ]}.


### PR DESCRIPTION
cowlib 2.0.0-pre.1 use `rand` module instead of `random` module, `random` module will be deprecated in erlang OTP 20+ release version.